### PR TITLE
v0.1.7 removed up down key for inter-section nav

### DIFF
--- a/src/components/KeyboardNavInstruction.vue
+++ b/src/components/KeyboardNavInstruction.vue
@@ -47,8 +47,8 @@
         <div class="shortcuts-section">
           <h3>Section Navigation</h3>
           <ul>
-            <li><kbd>↓</kbd> <kbd>→</kbd> Navigate from Search to Calendar section</li>
-            <li><kbd>↑</kbd> <kbd>←</kbd> Navigate from Calendar to Search section</li>
+            <li><kbd>→</kbd> Navigate from Search to Calendar section</li>
+            <li><kbd>←</kbd> Navigate from Calendar to Search section</li>
           </ul>
         </div>
 

--- a/src/utils/keyboardNavigation.util.ts
+++ b/src/utils/keyboardNavigation.util.ts
@@ -21,12 +21,12 @@ export const handleSectionKeyDown = (event: KeyboardEvent): void => {
       return
     }
 
-    if (isSearchSection && (event.key === 'ArrowRight' || event.key === 'ArrowDown')) {
+    if (isSearchSection && event.key === 'ArrowRight') {
       // Navigate from Search to Calendar
       event.preventDefault()
       const calendarElement = document.querySelector('.calendar') as HTMLElement
       if (calendarElement) calendarElement.focus()
-    } else if (isCalendarSection && (event.key === 'ArrowLeft' || event.key === 'ArrowUp')) {
+    } else if (isCalendarSection && event.key === 'ArrowLeft') {
       // Navigate from Calendar to Search
       event.preventDefault()
       const searchElement = document.querySelector('.search') as HTMLElement


### PR DESCRIPTION
This pull request simplifies the keyboard navigation between the Search and Calendar sections by removing the use of the up and down arrow keys. Now, only the left and right arrow keys are used for navigation.

Changes to keyboard navigation:

* [`src/components/KeyboardNavInstruction.vue`](diffhunk://#diff-08c70d2bb6693c608be3ffb65ef1cec2beffc02e4d7bc217bf208ecbb1c8c17bL50-R51): Updated the instructions to reflect the removal of the up and down arrow keys for navigation.
* [`src/utils/keyboardNavigation.util.ts`](diffhunk://#diff-d13d81d6a0a7377f280bf9d44233a28624f3bf8868f00427f490eb7b62e93ed7L24-R29): Modified the `handleSectionKeyDown` function to navigate between sections using only the left and right arrow keys.