### PR TITLE
v0.1.8 add back  "env.d.ts" in tsconfig.vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoticast-calendar-vue",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -2,9 +2,13 @@
   "extends": "./tsconfig.app.json",
   "include": [
     "src/**/__tests__/**/*.ts",
+    "env.d.ts",
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
-    "vitest.config.ts"
+    "src/**/*.vue",
+    "src/**/*.ts",
+    "vitest.config.ts",
+    "vite.config.ts"
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
This pull request includes updates to the project version and modifications to the TypeScript configuration for testing. The most important changes are:

Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `0.1.5` to `0.1.8`.

Testing configuration change back due to the removal [here](https://github.com/gehelloworld/spoticast-calendar-vue/pull/6/files#diff-b8589dbf31e43446973de0486544d67095d69ef8cc013283c44f2632bd32b3d4):
* [`tsconfig.vitest.json`](diffhunk://#diff-b8589dbf31e43446973de0486544d67095d69ef8cc013283c44f2632bd32b3d4R5-R11): Expanded the `include` array to incorporate additional TypeScript and Vue files, ensuring comprehensive test coverage.